### PR TITLE
Fix splitStream issue

### DIFF
--- a/convex/lib/openai.ts
+++ b/convex/lib/openai.ts
@@ -422,23 +422,21 @@ export class ChatCompletionContent {
       while (true) {
         const { value, done } = await reader.read();
         if (done) {
-          break;
+          // Flush the last fragment now that we're done
+          if (lastFragment !== "") {
+            yield lastFragment
+          }
+          break
         }
         const data = new TextDecoder().decode(value);
-        let startIdx = 0;
-        while (true) {
-          const endIdx = data.indexOf('\n\n', startIdx);
-          if (endIdx === -1) {
-            lastFragment += data.substring(startIdx);
-            break;
-          }
-          yield lastFragment + data.substring(startIdx, endIdx);
-          startIdx = endIdx + 2;
-          lastFragment = '';
+        lastFragment += data;
+        const parts = lastFragment.split("\n\n")
+        // Yield all except for the last part
+        for (let i =0; i < parts.length - 1; i += 1) {
+          yield parts[i]
         }
-      }
-      if (lastFragment) {
-        yield lastFragment;
+        // Save the last part as the new last fragment
+        lastFragment = parts[parts.length - 1]
       }
     } finally {
       reader.releaseLock();


### PR DESCRIPTION
Sometimes we'd get chunks like `data: {...}\n` followed by `\ndata: {...}` so the previous logic splitting on newline (and then truncating off `data: `) would skip chunks or fail to parse chunks.

The output looks a lot more reasonable now
`GOT RESPONSE \'dxe black to capture the pawn on e5 rook,.\''` vs. `GOT RESPONSE \'After the move dxe5, white captures the black pawn and gains an advantage in material.\''` (not that chatgpt is that good at analyzing chess, but at least it's vaguely a sentence now)